### PR TITLE
Fix: fixed badge to top right

### DIFF
--- a/pages/components/badge/badge.css
+++ b/pages/components/badge/badge.css
@@ -9,7 +9,7 @@
 	justify-content: center;
 	align-items: center;
 	padding: 1px;
-	bottom: 0px;
+	top: 0px;
 	right: 0px;
 	min-height: 2.5rem;
 	min-width: 2.5rem;
@@ -37,8 +37,8 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	bottom: -10px;
-	right: -10px;
+	top: -1.2rem;
+	right: -1.6rem;
 	height: 2.5rem;
 	width: 2.5rem;
 	background: var(--colour-error);


### PR DESCRIPTION
My badges were bottom right now made them top-right. 
# Before
![image](https://user-images.githubusercontent.com/67889207/154829638-0b0175b3-0343-4448-8bcd-65a2fd6b3776.png)
# After
![image](https://user-images.githubusercontent.com/67889207/154829678-6b554914-a87a-4b5e-8fe3-b985379750ed.png)
